### PR TITLE
Blosc download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
     - pip install coveralls
     - pip install json-spec
     - pip install simplejson regex wget
-    - pip install python-blosc
+    - pip install blosc
 cache:
     - pip
     - apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
     - pip install coveralls
     - pip install json-spec
     - pip install simplejson regex wget
-    - pip install blosc
+    - pip install python-blosc
 cache:
     - pip
     - apt

--- a/ndio/convert/blosc.py
+++ b/ndio/convert/blosc.py
@@ -8,16 +8,16 @@ def import_blosc(raw_data):
     Import a blosc array into a numpy array.
 
     Arguments:
-        raw_data:  A blosc packed numpy array 
+        raw_data:  A blosc packed numpy array
 
     Returns:
         A numpy array with data from a blosc compressed array
     """
 
     try:
-      numpy_data = blosc.unpack_array(raw_array)
+        numpy_data = blosc.unpack_array(raw_array)
     except Exception as e:
-        raise ValueError("Could not load numpy data from raw data. {}".format(e))
+        raise ValueError("Could not load numpy data. {}".format(e))
         raise
 
     return numpy_data
@@ -35,8 +35,8 @@ def export_blosc(numpy_data):
     """
 
     try:
-      raw_data = blosc.pack_array(numpy_data)
+        raw_data = blosc.pack_array(numpy_data)
     except Exception as e:
-        raise ValueError("Could not compress data from numpy array. {}".format(e))
+        raise ValueError("Could not compress data from array. {}".format(e))
 
     return raw_data

--- a/ndio/convert/nifti.py
+++ b/ndio/convert/nifti.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+import nibabel as nib
+import numpy
+import os
+import glob
+
+
+def import_nifti(nifti_filename):
+    """
+    Import a nifti file into a numpy array. TODO:  Currently only
+    transfers raw data for compatibility with annotation and ND formats
+
+    Arguments:
+        :nifti_filename:  A string filename of a nifti datafile
+
+    Returns:
+        A numpy array with data from the nifti file
+    """
+
+    # Expand filename to be absolute
+    nifti_filename = os.path.expanduser(nifti_filename)
+
+    try:
+        data = nib.load(nifti_filename)
+        img = data.get_data()
+
+    except Exception as e:
+        raise ValueError("Could not load file {0} for conversion."
+                         .format(nifti_filename))
+        raise
+
+    return numpy.array(img)
+
+
+def export_nifti(nifti_filename, numpy_data):
+    """
+    Export a numpy array to a nifti file.  TODO: currently using dummy
+    headers and identity matrix affine transform. This can be expanded.
+
+    Arguments:
+        nifti_filename:   A filename to which to save the nifti data
+        numpy_data:     The numpy array to save to nifti. OR a string
+
+    Returns:
+        String. The expanded filename that now holds the nifti data
+    """
+
+    # Expand filename to be absolute
+    nifti_filename = os.path.expanduser(nifti_filename)
+
+    try:
+        nifti_img = nib.Nifti1Image(numpy_data, numpy.eye(4))
+        nib.save(nifti_img, nifti_filename)
+
+    except Exception as e:
+        raise ValueError("Could not save file {0}.".format(nifti_filename))
+    return nifti_filename

--- a/ndio/remote/neurodata.py
+++ b/ndio/remote/neurodata.py
@@ -381,9 +381,8 @@ class neurodata(Remote):
                           req.status_code,
                           req.text))
 
-        # return numpy.squeeze(blosc.unpack_array(req.content))
-        return blosc.unpack_array(req.content)
-    
+        return blosc.unpack_array(req.content)[0] # TODO: 4D - 3D array
+        
         raise IOError("Failed to retrieve blosc cutout.")
 
     # SECTION:

--- a/ndio/remote/neurodata.py
+++ b/ndio/remote/neurodata.py
@@ -15,6 +15,7 @@ from .Remote import Remote
 from .errors import *
 import ndio.ramon as ramon
 from six.moves import range
+import six
 
 try:
     import urllib.request as urllib2
@@ -307,7 +308,7 @@ class neurodata(Remote):
 
         size = (x_stop-x_start)*(y_stop-y_start)*(z_stop-z_start)
 
-        if size < 2E9 and memory:  # TODO
+        if size < 2E9 and memory and six.PY2:  # TODO
             return self._get_cutout_blosc_no_chunking(token, channel,
                                                       resolution, x_start,
                                                       x_stop, y_start, y_stop,
@@ -381,8 +382,8 @@ class neurodata(Remote):
                           req.status_code,
                           req.text))
 
-        return blosc.unpack_array(req.content)[0] # TODO: 4D - 3D array
-        
+        return blosc.unpack_array(req.content)[0]  # TODO: 4D - 3D array
+
         raise IOError("Failed to retrieve blosc cutout.")
 
     # SECTION:


### PR DESCRIPTION
Fixed blosc download for python 2.x and kept compatibility for out of memory and python 3 (hdf5).  Added converters for nifti (very basic)
