### PR TITLE
Changing from PIL to tiffile

### DIFF
--- a/ndio/convert/tiff.py
+++ b/ndio/convert/tiff.py
@@ -3,7 +3,7 @@ from PIL import Image
 import numpy
 import os
 import glob
-
+import tifffile as tiff
 
 def load(tiff_filename):
     """
@@ -19,14 +19,13 @@ def load(tiff_filename):
     tiff_filename = os.path.expanduser(tiff_filename)
 
     try:
-        img = Image.open(tiff_filename)
+        img = tiff.imread(tiff_filename)
     except Exception as e:
         raise ValueError("Could not load file {0} for conversion."
                          .format(tiff_filename))
         raise
 
     return numpy.array(img)
-
 
 def save(tiff_filename, numpy_data):
     """
@@ -49,8 +48,7 @@ def save(tiff_filename, numpy_data):
         return png_filename
 
     try:
-        img = Image.fromarray(numpy_data)
-        img.save(tiff_filename)
+        img = tiff.imsave(tiff_filename, numpy_data)
     except Exception as e:
         raise ValueError("Could not save TIFF file {0}.".format(tiff_filename))
 
@@ -111,7 +109,7 @@ def load_tiff_multipage(tiff_filename, dtype='float32'):
         raise RuntimeError('could not find file "%s"' % tiff_filename)
 
     # load the data from multi-layer TIF files
-    data = Image.open(tiff_filename)
+    data = tiff.imread(tiff_filename)
 
     im = []
 

--- a/ndio/convert/tiff.py
+++ b/ndio/convert/tiff.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
-from PIL import Image
 import numpy
 import os
 import glob
 import tifffile as tiff
+
 
 def load(tiff_filename):
     """
@@ -26,6 +26,7 @@ def load(tiff_filename):
         raise
 
     return numpy.array(img)
+
 
 def save(tiff_filename, numpy_data):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pycollada
 blosc==1.3.2
 jsonschema
 json-spec
+tifffile

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ manipulation.',
         "requests",
         "blosc==1.3.2",
         "jsonschema",
-        "json-spec"
+        "json-spec",
+        "tifffile"
     ]
 )

--- a/tests/test_convert_image_export.py
+++ b/tests/test_convert_image_export.py
@@ -1,57 +1,56 @@
-# import unittest
-# import ndio.remote.neurodata as neurodata
-# import ndio.ramon
-# import ndio.convert.png as ndpng
-# import ndio.convert.tiff as ndtiff
-# import numpy
-#
-#
-# class TestDownload(unittest.TestCase):
-#
-#     def setUp(self):
-#         self.oo = neurodata()
-#
-#     def test_export_load(self):
-#         # kasthuri11/image/xy/3/1000,1100/1000,1100/1000/
-#         image_download = self.oo.get_image('kasthuri11', 'image',
-#                                            1000, 1100,
-#                                            1000, 1100,
-#                                            1000,
-#                                            resolution=3)
-#
-#         # if returns string, successful export
-#         self.assertEqual(
-#                 ndpng.export_png("tests/trash/download.png", image_download),
-#                 "tests/trash/download.png")
-#
-#         # now confirm import works too
-#         self.assertEqual(ndpng.load("tests/trash/download.png")[0][0],
-#                          image_download[0][0])
-#         self.assertEqual(ndpng.load("tests/trash/download.png")[10][10],
-#                          image_download[10][10])
-#
-#     def test_export_load(self):
-#         # kasthuri11/image/xy/3/1000,1100/1000,1100/1000/
-#         image_download = self.oo.get_image('kasthuri11', 'image',
-#                                            1000, 1100,
-#                                            1000, 1100,
-#                                            1000,
-#                                            resolution=3)
-#
-#         # if returns string, successful export
-#         self.assertEqual(
-#                 ndtiff.save("tests/trash/download-1.tiff",
-#                                    image_download),
-#                 "tests/trash/download-1.tiff")
-#
-#         # now confirm import works too
-#         self.assertEqual(
-#                 ndtiff.load("tests/trash/download-1.tiff")[0][0],
-#                 image_download[0][0])
-#         self.assertEqual(
-#                 ndtiff.load("tests/trash/download-1.tiff")[10][10],
-#                 image_download[10][10])
-#
-#
-# if __name__ == '__main__':
-#     unittest.main()
+import unittest
+import ndio.remote.neurodata as neurodata
+import ndio.ramon
+import ndio.convert.png as ndpng
+import ndio.convert.tiff as ndtiff
+import numpy
+
+
+class TestDownload(unittest.TestCase):
+
+    def setUp(self):
+        self.oo = neurodata()
+
+    def test_export_load(self):
+        # kasthuri11/image/xy/3/1000,1100/1000,1100/1000/
+        image_download = self.oo.get_image('kasthuri11', 'image',
+                                           1000, 1100,
+                                           1000, 1100,
+                                           1000,
+                                           resolution=3)
+
+        # if returns string, successful export
+        self.assertEqual(
+                ndpng.export_png("tests/trash/download.png", image_download),
+                "tests/trash/download.png")
+
+        # now confirm import works too
+        self.assertEqual(ndpng.load("tests/trash/download.png")[0][0],
+                         image_download[0][0])
+        self.assertEqual(ndpng.load("tests/trash/download.png")[10][10],
+                         image_download[10][10])
+
+    def test_export_load(self):
+        # kasthuri11/image/xy/3/1000,1100/1000,1100/1000/
+        image_download = self.oo.get_image('kasthuri11', 'image',
+                                           1000, 1100,
+                                           1000, 1100,
+                                           1000,
+                                           resolution=3)
+
+        # if returns string, successful export
+        self.assertEqual(
+                         ndtiff.save("tests/trash/download-1.tiff",
+                                     image_download),
+                         "tests/trash/download-1.tiff")
+
+        # now confirm import works too
+        self.assertEqual(
+                         ndtiff.load("tests/trash/download-1.tiff")[0][0],
+                         image_download[0][0])
+        self.assertEqual(
+                         ndtiff.load("tests/trash/download-1.tiff")[10][10],
+                         image_download[10][10])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This proposed change will move convert/tiff from PIL reliance to tifffile, which appears to be more useful/less prone to cause problems during conversion.
